### PR TITLE
Challenge-6 Add gitignore to prevent credentials leak

### DIFF
--- a/challenge-6/base-folder/.gitignore
+++ b/challenge-6/base-folder/.gitignore
@@ -1,0 +1,1 @@
+default-creds.txt


### PR DESCRIPTION
Hi there! I hope you don't mind the drive-by PR (I promise I only do this sometimes!)

I noticed there's a `.gitignore` for the `.aws` folder in challenge-6, but there's no `.gitignore` for the credentials file generated by Terraform under `base-folder/default-creds.txt`.

This just adds that generated file to a corresponding `.gitignore` so it's not accidentally committed to source control :-)